### PR TITLE
I2c support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.egg-info
 dist
 build
+.*.sw[po]

--- a/poetry.lock
+++ b/poetry.lock
@@ -73,6 +73,19 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "smbus2"
+version = "0.4.1"
+description = "smbus2 is a drop-in replacement for smbus-cffi/smbus-python in pure Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+docs = ["sphinx (>=1.5.3)"]
+qa = ["flake8"]
+test = ["nose", "mock"]
+
+[[package]]
 name = "spidev"
 version = "3.5"
 description = "Python bindings for Linux SPI access through spidev"
@@ -83,7 +96,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "69f149033c2451ac35daee226d805ea9fe1f6f902432d19f44611bdedbbd0cc4"
+content-hash = "2374cf772d581eb95eab9d7565616f4788480cb9318f460e8348e3efd5384d9f"
 
 [metadata.files]
 decorator = [
@@ -228,6 +241,10 @@ retry = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+smbus2 = [
+    {file = "smbus2-0.4.1-py2.py3-none-any.whl", hash = "sha256:8b1e70cda011b6fb3caf8377a1084f73a5aa99392b78529f140b0a3f06468f6c"},
+    {file = "smbus2-0.4.1.tar.gz", hash = "sha256:6276eb599b76c4e74372f2582d2282f03b4398f0da16bc996608e4f21557ca9b"},
 ]
 spidev = [
     {file = "spidev-3.5.tar.gz", hash = "sha256:8a7f5c289f161ea2ac4697fa8a10918232c990678dd0053084b3c43b1363910d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ grpcio = "^1.44.0"
 protobuf = "^3.20.1"
 "RPi.GPIO" = "^0.7.1"
 retry = "^0.9.2"
+smbus2 = "^0.4.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/sigmadsp/application/backend.py
+++ b/sigmadsp/application/backend.py
@@ -33,7 +33,7 @@ from sigmadsp.generated.backend_service.control_pb2_grpc import (
     add_BackendServicer_to_server,
 )
 from sigmadsp.hardware.adau14xx import Adau14xx
-from sigmadsp.hardware.dsp import SafetyCheckException
+from sigmadsp.hardware.dsp import ConfigurationError, SafetyCheckException
 from sigmadsp.helper.settings import SigmadspSettings
 
 # A logger for this module
@@ -80,12 +80,17 @@ class BackendService(BackendServicer):
 
         logger.info("Specified DSP type is '%s' over %s.", dsp_type, dsp_protocol)
 
-        if dsp_type == "adau14xx":
-            self.dsp = Adau14xx(self.settings.config)
+        try:
+            if dsp_type == "adau14xx":
+                self.dsp = Adau14xx(self.settings.config)
 
-        else:
-            logger.error("DSP type '%s' is not known! Aborting.", dsp_type)
-            sys.exit(0)
+            else:
+                logger.error("DSP type '%s' is not known! Aborting.", dsp_type)
+                sys.exit(1)
+
+        except ConfigurationError:
+            logger.error("DSP configuration is broken! Aborting")
+            sys.exit(1)
 
         try:
             logger.info("Run startup safety check.")

--- a/sigmadsp/application/backend.py
+++ b/sigmadsp/application/backend.py
@@ -78,7 +78,7 @@ class BackendService(BackendServicer):
         worker_thread.daemon = True
         worker_thread.start()
 
-        logger.info("Specified DSP type is '%s' over %s.", dsp_type, dsp_protocol)
+        logger.info("Specified DSP type is '%s', using the '%s' protocol.", dsp_type, dsp_protocol)
 
         try:
             if dsp_type == "adau14xx":
@@ -125,11 +125,11 @@ class BackendService(BackendServicer):
 
         else:
             dsp_hash = self.dsp.get_parameter_value(safety_hash_cell.parameter_address, data_format="int")
-            logger.info("safety hash address: 0x%04x", safety_hash_cell.parameter_address)
+            logger.info("Safety hash address: 0x%04x.", safety_hash_cell.parameter_address)
 
             if safety_hash_cell.parameter_value != dsp_hash:
                 logger.warning(
-                    "Safety hash cell content does not match! params: %d, dsp: %d. Configuration remains locked.",
+                    "Safety hash cell content does not match! Expected %d, but read %d. Configuration remains locked.",
                     safety_hash_cell.parameter_value,
                     dsp_hash,
                 )

--- a/sigmadsp/application/frontend.py
+++ b/sigmadsp/application/frontend.py
@@ -4,6 +4,7 @@ It can control the backend via the command line.
 """
 import argparse
 import logging
+from typing import Union
 
 import grpc
 

--- a/sigmadsp/application/frontend.py
+++ b/sigmadsp/application/frontend.py
@@ -87,7 +87,7 @@ def main():
     if arguments.address is not None:
         backend_address = arguments.address
 
-    response: ControlResponse
+    response: ControlResponse = None
     control_request = ControlRequest()
     control_parameter_request = ControlParameterRequest()
 
@@ -124,7 +124,7 @@ def main():
 
             response = stub.control(control_request)
 
-    logging.info(response.message)
+        logging.info(response and response.message)
 
 
 if __name__ == "__main__":

--- a/sigmadsp/application/frontend.py
+++ b/sigmadsp/application/frontend.py
@@ -87,7 +87,7 @@ def main():
     if arguments.address is not None:
         backend_address = arguments.address
 
-    response: ControlResponse = None
+    response: Union[ControlResponse, None] = None
     control_request = ControlRequest()
     control_parameter_request = ControlParameterRequest()
 

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -151,7 +151,8 @@ class Adau14xx(Dsp):
             data (bytes): Data to write; multiple parameters should be concatenated
             count (int): Number of 4 byte words to write
         """
-        count = min(count, 5)
+        if count > len(Adau14xx.SAFELOAD_DATA_REGISTERS):
+            raise IndexError(f"Cannot write {count * 4} bytes by means of software safeload, the maximum is {len(Adau14xx.SAFELOAD_DATA_REGISTERS) * 4} bytes.")
         for register_index, register_address in zip(range(count), Adau14xx.SAFELOAD_DATA_REGISTERS):
             data_buf = data[
                 register_index * self.FIXPOINT_REGISTER_LENGTH : (register_index + 1) * self.FIXPOINT_REGISTER_LENGTH

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -149,7 +149,7 @@ class Adau14xx(Dsp):
 
         Args:
             address (int): Address to write to
-            data (bytes): Data to write; multiple parameter should be concatenated
+            data (bytes): Data to write; multiple parameters should be concatenated
             count (int): Number of words to write
         """
         for sd in range(0, count):

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -1,10 +1,9 @@
 """This module provides functionality for controlling SigmaDSP hardware, e.g.
 
+- Deploying programs
 - Changing parameter register contents
 - Reading parameter registers
 - Performing soft reset
-
-For this, it uses the SpiHandler module, to interface to the DSP.
 """
 import logging
 from typing import Union
@@ -46,8 +45,8 @@ class Adau14xx(Dsp):
 
         Set and release the corresponding register for resetting.
         """
-        self.comm_handler.write(Adau14xx.RESET_REGISTER, int16_to_bytes(0))
-        self.comm_handler.write(Adau14xx.RESET_REGISTER, int16_to_bytes(1))
+        self.protocol_handler.write(Adau14xx.RESET_REGISTER, int16_to_bytes(0))
+        self.protocol_handler.write(Adau14xx.RESET_REGISTER, int16_to_bytes(1))
         logger.info("Soft-resetting the DSP.")
 
     def get_parameter_value(self, address: int, data_format: str) -> Union[float, int, None]:

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -45,8 +45,8 @@ class Adau14xx(Dsp):
 
         Set and release the corresponding register for resetting.
         """
-        self.protocol_handler.write(Adau14xx.RESET_REGISTER, int16_to_bytes(0))
-        self.protocol_handler.write(Adau14xx.RESET_REGISTER, int16_to_bytes(1))
+        self.write(Adau14xx.RESET_REGISTER, int16_to_bytes(0))
+        self.write(Adau14xx.RESET_REGISTER, int16_to_bytes(1))
         logger.info("Soft-resetting the DSP.")
 
     def get_parameter_value(self, address: int, data_format: str) -> Union[float, int, None]:

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -153,7 +153,8 @@ class Adau14xx(Dsp):
         """
         if count > len(Adau14xx.SAFELOAD_DATA_REGISTERS):
             raise IndexError(
-                f"Cannot write {count * 4} bytes by means of software safeload, the maximum is {len(Adau14xx.SAFELOAD_DATA_REGISTERS) * 4} bytes."
+                f"Cannot write {count * 4} bytes by means of software safeload, the maximum is "
+                f"{len(Adau14xx.SAFELOAD_DATA_REGISTERS) * 4} bytes."
             )
         for register_index, register_address in zip(range(count), Adau14xx.SAFELOAD_DATA_REGISTERS):
             data_buf = data[

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -36,7 +36,7 @@ class Adau14xx(Dsp):
     SAFELOAD_DATA_REGISTERS = [0x6000, 0x6001, 0x6002, 0x6003, 0x6004]
     SAFELOAD_ADDRESS_REGISTER = 0x6005
     SAFELOAD_COUNT_REGISTER = 0x6006
-    SAFELOAD_DATA_REGISTER_LENGTH = 5
+    SAFELOAD_DATA_REGISTER_LENGTH = 4
 
     # All fixpoint (parameter) registers are four bytes long
     FIXPOINT_REGISTER_LENGTH = 4
@@ -154,8 +154,7 @@ class Adau14xx(Dsp):
         """
         for sd in range(0, count):
             register = self.SAFELOAD_DATA_REGISTERS[sd]
-            data_buf = bytearray(self.SAFELOAD_DATA_REGISTER_LENGTH)
-            data_buf[1:] = data[sd * self.FIXPOINT_REGISTER_LENGTH : sd * (self.FIXPOINT_REGISTER_LENGTH + 1)]
+            data_buf = data[sd * self.FIXPOINT_REGISTER_LENGTH : (sd + 1) * self.FIXPOINT_REGISTER_LENGTH]
             self.write(register, data_buf)
 
         self.write(self.SAFELOAD_ADDRESS_REGISTER, int32_to_bytes(address))

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -152,8 +152,8 @@ class Adau14xx(Dsp):
             data (bytes): Data to write; multiple parameters should be concatenated
             count (int): Number of words to write
         """
-        for sd in range(0, count):
-            register = self.SAFELOAD_DATA_REGISTERS[sd]
+        for register_index, register_address in zip(range(count), Adau14xx.SAFELOAD_DATA_REGISTERS):
+            register_address = Adau14xx.SAFELOAD_DATA_REGISTERS[sd]
             data_buf = data[sd * self.FIXPOINT_REGISTER_LENGTH : (sd + 1) * self.FIXPOINT_REGISTER_LENGTH]
             self.write(register, data_buf)
 

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -150,14 +150,15 @@ class Adau14xx(Dsp):
         Args:
             address (int): Address to write to
             data (bytes): Data to write; multiple parameters should be concatenated
-            count (int): Number of words to write
+            count (int): Number of 4 byte words to write
         """
+        count = min(count, 5)
         for register_index, register_address in zip(range(count), Adau14xx.SAFELOAD_DATA_REGISTERS):
-            register_address = Adau14xx.SAFELOAD_DATA_REGISTERS[sd]
-            data_buf = data[sd * self.FIXPOINT_REGISTER_LENGTH : (sd + 1) * self.FIXPOINT_REGISTER_LENGTH]
-            self.write(register, data_buf)
+            data_buf = data[
+                register_index * self.FIXPOINT_REGISTER_LENGTH : (register_index + 1) * self.FIXPOINT_REGISTER_LENGTH
+            ]
+            self.write(register_address, data_buf)
 
+        # TODO: test if the address is supposed to be shifted down by 1 as old forum posts suggest
         self.write(self.SAFELOAD_ADDRESS_REGISTER, int32_to_bytes(address))
-
-        # TODO: test if this is supposed to be a regular integer or it needs to be encoded as 8.24
         self.write(self.SAFELOAD_COUNT_REGISTER, int32_to_bytes(count))

--- a/sigmadsp/hardware/adau14xx.py
+++ b/sigmadsp/hardware/adau14xx.py
@@ -152,7 +152,9 @@ class Adau14xx(Dsp):
             count (int): Number of 4 byte words to write
         """
         if count > len(Adau14xx.SAFELOAD_DATA_REGISTERS):
-            raise IndexError(f"Cannot write {count * 4} bytes by means of software safeload, the maximum is {len(Adau14xx.SAFELOAD_DATA_REGISTERS) * 4} bytes.")
+            raise IndexError(
+                f"Cannot write {count * 4} bytes by means of software safeload, the maximum is {len(Adau14xx.SAFELOAD_DATA_REGISTERS) * 4} bytes."
+            )
         for register_index, register_address in zip(range(count), Adau14xx.SAFELOAD_DATA_REGISTERS):
             data_buf = data[
                 register_index * self.FIXPOINT_REGISTER_LENGTH : (register_index + 1) * self.FIXPOINT_REGISTER_LENGTH

--- a/sigmadsp/hardware/base.py
+++ b/sigmadsp/hardware/base.py
@@ -1,0 +1,98 @@
+"""This module implements the base class for I2C and SPI communication handlers."""
+import logging
+import threading
+from abc import abstractmethod
+from multiprocessing import Pipe
+
+# A logger for this module
+logger = logging.getLogger(__name__)
+
+
+class HandlerBase:
+    """Base class for communication handlers talking to SigmaDSP chipsets."""
+
+    # cosmetic use only
+    PROTOCOL: str
+
+    def __init__(self, bus: int = 0, device: int = 0):
+        """Initialize the communications thread."""
+        self._initialize(bus, device)
+
+        # Generate a Pipe, for communicating with the I2C handler thread within this class.
+        self.pipe_end_owner, self.pipe_end_user = Pipe()
+
+        logger.info("Starting %s handling thread.", self.PROTOCOL)
+        self.thread = threading.Thread(target=self.serve_forever, name=f"{self.PROTOCOL} handler thread")
+        self.thread.daemon = True
+        self.thread.start()
+
+    def write(self, address: int, data: bytes):
+        """Write data over the hardware interface via the pipe to the hardware thread.
+
+        Args:
+            address (int): DSP register address to write to
+            data (bytes): Binary data to write
+        """
+        self.pipe_end_owner.send("write")
+        self.pipe_end_owner.send((address, data))
+
+    def read(self, address: int, length: int) -> bytes:
+        """Read data from the hardware interface via the pipe to the hardware thread.
+
+        Args:
+            address (int): DSP register address to read from
+            length (int): Number of bytes to read
+
+        Returns:
+            bytes: Register content
+        """
+        self.pipe_end_owner.send("read")
+        self.pipe_end_owner.send((address, length))
+
+        data = self.pipe_end_owner.recv()
+
+        return data
+
+    def serve_forever(self):
+        """Handle incoming requests for writing or reading data."""
+        while True:
+            mode = self.pipe_end_user.recv()
+
+            if mode == "write":
+                address, data = self.pipe_end_user.recv()
+                self._write(address, data)
+
+            elif mode == "read":
+                address, length = self.pipe_end_user.recv()
+                data = self._read(address, length)
+                self.pipe_end_user.send(data)
+
+    @abstractmethod
+    def _initialize(self, bus: int = 0, device: int = 0):
+        """Initialize the hardware.
+
+        Args:
+            bus (int, optional): Bus number. Defaults to 0.
+            device (int, optional): Device number / address. Defaults to 0
+        """
+
+    @abstractmethod
+    def _read(self, address: int, length: int) -> bytes:
+        """Read data from a SigmaDSP.
+
+        Args:
+            address (int): Address to read from
+            length (int): Number of bytes to read
+
+        Returns:
+            bytes: Data that was read from the DSP
+        """
+
+    @abstractmethod
+    def _write(self, address: int, data: bytes):
+        """Write data onto a SigmaDSP.
+
+        Args:
+            address (int): Address to write to
+            data (bytes): Data to write
+        """

--- a/sigmadsp/hardware/dsp.py
+++ b/sigmadsp/hardware/dsp.py
@@ -3,7 +3,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Union
+from typing import Dict, List, Type, Union
 
 import gpiozero
 
@@ -75,13 +75,13 @@ class Dsp(ABC):
         self.pins: List[Pin] = []
         self.parse_config()
 
-        protocol_handlers: dict[str, type[BaseProtocol]] = {
+        protocol_handlers: Dict[str, Type[BaseProtocol]] = {
             "i2c": I2C,
             "spi": SPI,
         }
 
         try:
-            handler_class: type[BaseProtocol] = protocol_handlers[self.protocol]
+            handler_class: Type[BaseProtocol] = protocol_handlers[self.protocol]
             self.protocol_handler = handler_class(bus=self.bus, device=self.address)
         except KeyError as e:
             logger.error("Unknown protocol: %s", self.protocol)

--- a/sigmadsp/hardware/dsp.py
+++ b/sigmadsp/hardware/dsp.py
@@ -64,9 +64,13 @@ class Dsp(ABC):
     """A generic DSP class, to be extended by child classes."""
 
     protocol_handler: BaseProtocol
+    type: str
+    protocol: str
+    bus: int
+    address: int
 
     def __init__(self, config: dict):
-        """Initialize the DSP with an SpiHandler that talks to it.
+        """Initialize the DSP and set up the protocol handler that talks to it.
 
         Args:
             config (dict): Configuration settings, from the general configuration file.

--- a/sigmadsp/hardware/dsp.py
+++ b/sigmadsp/hardware/dsp.py
@@ -125,7 +125,7 @@ class Dsp(ABC):
             self.bus = self.config["dsp"]["bus_number"]
             self.address = self.config["dsp"]["device_address"]
         except KeyError as e:
-            logger.error("Key %s missing from DSP configuration.", e.message)
+            logger.error("Key %s missing from the DSP configuration.", e.args[0])
             raise ConfigurationError from e
 
     def get_pin_by_name(self, name: str) -> Union[Pin, None]:

--- a/sigmadsp/hardware/dsp.py
+++ b/sigmadsp/hardware/dsp.py
@@ -209,5 +209,5 @@ class Dsp:
         Args:
             address (int): Address to write to
             data (bytes): Data to write
-            count (int): Number of words to write (max. 5)
+            count (int): Number of 4 byte words to write (max. 5)
         """

--- a/sigmadsp/hardware/dsp.py
+++ b/sigmadsp/hardware/dsp.py
@@ -7,6 +7,7 @@ from typing import List, Union
 
 import gpiozero
 
+from sigmadsp.hardware.base import HandlerBase
 from sigmadsp.hardware.i2c import I2cHandler
 from sigmadsp.hardware.spi import SpiHandler
 
@@ -58,7 +59,7 @@ class OutputPin(Pin):
 class Dsp:
     """A generic DSP class, to be extended by child classes."""
 
-    comm_handler: Union[I2cHandler, SpiHandler]
+    comm_handler: HandlerBase
 
     def __init__(self, config: dict):
         """Initialize the DSP with an SpiHandler that talks to it.
@@ -72,7 +73,7 @@ class Dsp:
         self.parse_config()
 
         if self.protocol == "i2c":
-            self.comm_handler = I2cHandler(i2c_bus=self.i2c_bus, i2c_addr=self.i2c_address)
+            self.comm_handler = I2cHandler(bus=self.i2c_bus, device=self.i2c_address)
         else:
             self.comm_handler = SpiHandler()
 

--- a/sigmadsp/hardware/i2c.py
+++ b/sigmadsp/hardware/i2c.py
@@ -21,7 +21,7 @@ class I2cHandler:
     ADDRESS_LENGTH = 2
 
     def __init__(self, i2c_bus: int = 1, i2c_addr: int = 0x34):
-        """Initialize the SpiHandler thread."""
+        """Initialize the I2cHandler thread."""
         self._initialize_i2c(i2c_bus, i2c_addr)
 
         # Generate a Pipe, for communicating with the I2C handler thread within this class.

--- a/sigmadsp/hardware/i2c.py
+++ b/sigmadsp/hardware/i2c.py
@@ -1,91 +1,36 @@
 """This module implements an I2C handler that talks to Sigma DSP devices."""
 import logging
-import threading
-from multiprocessing import Pipe
 
 from smbus2 import SMBus, i2c_msg
 
+from sigmadsp.hardware.base import HandlerBase
 from sigmadsp.helper.conversion import int16_to_bytes
 
 # A logger for this module
 logger = logging.getLogger(__name__)
 
 
-class I2cHandler:
+class I2cHandler(HandlerBase):
     """Handle I2C transfers from and to SigmaDSP chipsets.
 
     Tested with ADAU1701
     """
 
-    # Length of addresses (in bytes) for accessing registers
-    ADDRESS_LENGTH = 2
+    PROTOCOL = "I2C"
 
-    def __init__(self, i2c_bus: int = 1, i2c_addr: int = 0x34):
-        """Initialize the I2cHandler thread."""
-        self._initialize_i2c(i2c_bus, i2c_addr)
-
-        # Generate a Pipe, for communicating with the I2C handler thread within this class.
-        self.pipe_end_owner, self.pipe_end_user = Pipe()
-
-        logger.info("Starting I2C handling thread.")
-        self.thread = threading.Thread(target=self.serve_forever, name="I2C handler thread")
-        self.thread.daemon = True
-        self.thread.start()
-
-    def _initialize_i2c(self, bus: int = 1, device: int = 0x34):
+    def _initialize(self, bus: int = 1, device: int = 0x38):
         """Initialize the I2C hardware.
 
         Bus will be 1 for RaspberryPi hardware.
 
         Args:
             bus (int, optional): Bus number. Defaults to 1.
-            device (int, optional): Device number. Defaults to 0x34.
+            device (int, optional): Device number. Defaults to 0x38. (ADAU145x default address)
         """
         self.bus = SMBus(bus)
         self.i2c_addr = device
 
-    def write(self, address: int, data: bytes):
-        """Write data over the I2C interface via the pipe to the I2C thread.
-
-        Args:
-            address (int): DSP register address to write to
-            data (bytes): Binary data to write
-        """
-        self.pipe_end_owner.send("write")
-        self.pipe_end_owner.send((address, data))
-
-    def read(self, address: int, length: int) -> bytes:
-        """Read data from the I2C interface via the pipe to the I2C thread.
-
-        Args:
-            address (int): DSP register address to read from
-            length (int): Number of bytes to read
-
-        Returns:
-            bytes: Register content
-        """
-        self.pipe_end_owner.send("read")
-        self.pipe_end_owner.send((address, length))
-
-        data = self.pipe_end_owner.recv()
-
-        return data
-
-    def serve_forever(self):
-        """Handle incoming requests for writing or reading data over SPI."""
-        while True:
-            mode = self.pipe_end_user.recv()
-
-            if mode == "write":
-                address, data = self.pipe_end_user.recv()
-                self._write_i2c(address, data)
-
-            elif mode == "read":
-                address, length = self.pipe_end_user.recv()
-                data = self._read_i2c(address, length)
-                self.pipe_end_user.send(data)
-
-    def _read_i2c(self, address: int, length: int) -> bytes:
+    def _read(self, address: int, length: int) -> bytes:
         """Read data over the i2c port from a SigmaDSP.
 
         Args:
@@ -105,7 +50,7 @@ class I2cHandler:
 
         return rd_list
 
-    def _write_i2c(self, address: int, data: bytes):
+    def _write(self, address: int, data: bytes):
         """Write data over the I2C port onto a SigmaDSP.
 
         Args:

--- a/sigmadsp/hardware/i2c.py
+++ b/sigmadsp/hardware/i2c.py
@@ -55,7 +55,7 @@ class I2cHandler:
         self.pipe_end_owner.send((address, data))
 
     def read(self, address: int, length: int) -> bytes:
-        """Read data from the SPI interface via the pipe to the SPI thread.
+        """Read data from the I2C interface via the pipe to the I2C thread.
 
         Args:
             address (int): DSP register address to read from

--- a/sigmadsp/hardware/i2c.py
+++ b/sigmadsp/hardware/i2c.py
@@ -3,20 +3,18 @@ import logging
 
 from smbus2 import SMBus, i2c_msg
 
-from sigmadsp.hardware.base import HandlerBase
+from sigmadsp.hardware.base_protocol import BaseProtocol
 from sigmadsp.helper.conversion import int16_to_bytes
 
 # A logger for this module
 logger = logging.getLogger(__name__)
 
 
-class I2cHandler(HandlerBase):
+class I2C(BaseProtocol):
     """Handle I2C transfers from and to SigmaDSP chipsets.
 
     Tested with ADAU1701
     """
-
-    PROTOCOL = "I2C"
 
     def _initialize(self, bus: int = 1, device: int = 0x38):
         """Initialize the I2C hardware.

--- a/sigmadsp/hardware/i2c.py
+++ b/sigmadsp/hardware/i2c.py
@@ -1,0 +1,120 @@
+"""This module implements an SPI handler that talks to Sigma DSP devices."""
+import logging
+import threading
+from multiprocessing import Pipe
+
+from smbus2 import SMBus, i2c_msg
+
+from sigmadsp.helper.conversion import int16_to_bytes
+
+# A logger for this module
+logger = logging.getLogger(__name__)
+
+
+class I2cHandler:
+    """Handle I2C transfers from and to SigmaDSP chipsets.
+
+    Tested with ADAU1701
+    """
+
+    # Length of addresses (in bytes) for accessing registers
+    ADDRESS_LENGTH = 2
+
+    def __init__(self, i2c_bus: int = 1, i2c_addr: int = 0x34):
+        """Initialize the SpiHandler thread."""
+        self._initialize_i2c(i2c_bus, i2c_addr)
+
+        # Generate a Pipe, for communicating with the I2C handler thread within this class.
+        self.pipe_end_owner, self.pipe_end_user = Pipe()
+
+        logger.info("Starting I2C handling thread.")
+        self.thread = threading.Thread(target=self.serve_forever, name="I2C handler thread")
+        self.thread.daemon = True
+        self.thread.start()
+
+    def _initialize_i2c(self, bus: int = 1, device: int = 0x34):
+        """Initialize the I2C hardware.
+
+        Bus will be 1 for RaspberryPi hardware.
+
+        Args:
+            bus (int, optional): Bus number. Defaults to 1.
+            device (int, optional): Device number. Defaults to 0x34.
+        """
+        self.bus = SMBus(bus)
+        self.i2c_addr = device
+
+    def write(self, address: int, data: bytes):
+        """Write data over the SPI interface via the pipe to the SPI thread.
+
+        Args:
+            address (int): DSP register address to write to
+            data (bytes): Binary data to write
+        """
+        self.pipe_end_owner.send("write")
+        self.pipe_end_owner.send((address, data))
+
+    def read(self, address: int, length: int) -> bytes:
+        """Read data from the SPI interface via the pipe to the SPI thread.
+
+        Args:
+            address (int): DSP register address to read from
+            length (int): Number of bytes to read
+
+        Returns:
+            bytes: Register content
+        """
+        self.pipe_end_owner.send("read")
+        self.pipe_end_owner.send((address, length))
+
+        data = self.pipe_end_owner.recv()
+
+        return data
+
+    def serve_forever(self):
+        """Handle incoming requests for writing or reading data over SPI."""
+        while True:
+            mode = self.pipe_end_user.recv()
+
+            if mode == "write":
+                address, data = self.pipe_end_user.recv()
+                self._write_i2c(address, data)
+
+            elif mode == "read":
+                address, length = self.pipe_end_user.recv()
+                data = self._read_i2c(address, length)
+                self.pipe_end_user.send(data)
+
+    def _read_i2c(self, address: int, length: int) -> bytes:
+        """Read data over the i2c port from a SigmaDSP.
+
+        Args:
+            address (int): Address to read from
+            length (int): Number of bytes to read
+
+        Returns:
+            bytes: Data that was read from the DSP
+        """
+        address_bytes = list(int16_to_bytes(address))
+
+        msg_wr = i2c_msg.write(self.i2c_addr, address_bytes)
+        msg_rd = i2c_msg.read(self.i2c_addr, length)
+
+        self.bus.i2c_rdwr(msg_wr, msg_rd)
+        rd_list = bytes(msg_rd)
+
+        return rd_list
+
+    def _write_i2c(self, address: int, data: bytes):
+        """Write data over the I2C port onto a SigmaDSP.
+
+        Args:
+            address (int): Address to write to
+            data (bytes): Data to write
+        """
+        wr_content = list(int16_to_bytes(address))
+        wr_content.extend(list(data))
+
+        msg_wr = i2c_msg.write(self.i2c_addr, wr_content)
+
+        self.bus.i2c_rdwr(msg_wr)

--- a/sigmadsp/hardware/i2c.py
+++ b/sigmadsp/hardware/i2c.py
@@ -45,7 +45,7 @@ class I2cHandler:
         self.i2c_addr = device
 
     def write(self, address: int, data: bytes):
-        """Write data over the SPI interface via the pipe to the SPI thread.
+        """Write data over the I2C interface via the pipe to the I2C thread.
 
         Args:
             address (int): DSP register address to write to

--- a/sigmadsp/hardware/i2c.py
+++ b/sigmadsp/hardware/i2c.py
@@ -1,4 +1,4 @@
-"""This module implements an SPI handler that talks to Sigma DSP devices."""
+"""This module implements an I2C handler that talks to Sigma DSP devices."""
 import logging
 import threading
 from multiprocessing import Pipe

--- a/templates/.env
+++ b/templates/.env
@@ -15,14 +15,14 @@ export CONFIGURATION_FILE=config.yaml
 # The default DSP type. This is written into the configuration file.
 export DSP_TYPE=adau14xx
 
-# The default DSP protocol. This is written into the configuration file.
+# The default DSP protocol (spi or i2c). This is written into the configuration file.
 export DSP_PROTOCOL=spi
 
-# The default I2C bus (1 is the correct value for raspberrypi). This is written into the configuration file.
-export I2C_BUS=1
+# The default communication bus; for Raspberry Pi, you'll want bus 0 fir SPI and bus 1 for I2C. This is written into the configuration file.
+export BUS_NUMBER=0
 
-# The default I2C device address (0x38 is the default for ADAU145x). This is written into the configuration file.
-export I2C_ADDRESS=0x38
+# The default device address (0 for SPI; for I2C, 0x38 is the default for ADAU145x, 0x34 is the default for ADAU1701). This is written into the configuration file.
+export DEVICE_ADDRESS=0
 
 # The default parameter file name. This file stores DSP application parameters.
 export PARAMETER_FILE=current.params

--- a/templates/.env
+++ b/templates/.env
@@ -15,6 +15,15 @@ export CONFIGURATION_FILE=config.yaml
 # The default DSP type. This is written into the configuration file.
 export DSP_TYPE=adau14xx
 
+# The default DSP protocol. This is written into the configuration file.
+export DSP_PROTOCOL=spi
+
+# The default I2C bus (1 is the correct value for raspberrypi). This is written into the configuration file.
+export I2C_BUS=1
+
+# The default I2C device address (0x34 is the default for ADAU145x). This is written into the configuration file.
+export I2C_ADDRESS=0x38
+
 # The default parameter file name. This file stores DSP application parameters.
 export PARAMETER_FILE=current.params
 

--- a/templates/.env
+++ b/templates/.env
@@ -21,7 +21,7 @@ export DSP_PROTOCOL=spi
 # The default I2C bus (1 is the correct value for raspberrypi). This is written into the configuration file.
 export I2C_BUS=1
 
-# The default I2C device address (0x34 is the default for ADAU145x). This is written into the configuration file.
+# The default I2C device address (0x38 is the default for ADAU145x). This is written into the configuration file.
 export I2C_ADDRESS=0x38
 
 # The default parameter file name. This file stores DSP application parameters.

--- a/templates/config.yaml.template
+++ b/templates/config.yaml.template
@@ -22,9 +22,8 @@ dsp:
   type: "$DSP_TYPE"
   # the protocol used to communicate (spi or i2c)
   protocol: "$DSP_PROTOCOL"
-  # for I2C
-  i2c_bus: "$I2C_BUS"
-  i2c_address: "$I2C_ADDRESS"
+  bus_number: "$BUS_NUMBER"
+  device_address: "$DEVICE_ADDRESS"
 
   pins:
     # The DSP's hardware reset pin.

--- a/templates/config.yaml.template
+++ b/templates/config.yaml.template
@@ -20,6 +20,11 @@ parameters:
 dsp:
   # The type of the DSP to control with the $SIGMADSP_BACKEND service.
   type: "$DSP_TYPE"
+  # the protocol used to communicate (spi or i2c)
+  protocol: "$DSP_PROTOCOL"
+  # for I2C
+  i2c_bus: "$I2C_BUS"
+  i2c_address: "$I2C_ADDRESS"
 
   pins:
     # The DSP's hardware reset pin.


### PR DESCRIPTION
Related to #12 - I decided to split it in two; this one adds I2C support and separates the communication concerns. It also adds an untested safeload implementation for ADAU145x (it's simple enough, the only thing I'm unsure about is the format of the number of words - I _think_ it's correct, because the compiler output example they show has the address and the number as int32, and this is not something used in calculations, but I've been surprised by sigmastudio in my brief experience with it).

The safeload method is not used at this stage, it will come with the next PR (ADAU1701 support and `sigma_tcp_server` changes).