### PR TITLE
Fix: rerun safety check after reset

### DIFF
--- a/sigmadsp/backend.py
+++ b/sigmadsp/backend.py
@@ -16,7 +16,7 @@ from multiprocessing import Queue
 from typing import Callable, Dict
 
 import grpc
-from retry import retry
+from retry.api import retry_call
 
 import sigmadsp
 from sigmadsp.dsp.common import ConfigurationError, Dsp, SafetyCheckError
@@ -135,7 +135,7 @@ class BackendService(BackendServicer):
 
     def retry_safety_check(self) -> None:
         """The ``safety_check``, but with retries."""
-        retry(SafetyCheckError, 5, 5)(self.safety_check)
+        retry_call(self.safety_check, exceptions=SafetyCheckError, tries=5, delay=5)
 
     def safety_check(self) -> None:
         """Check a hash cell within the DSP's memory against a hash value from the parameter file.

--- a/sigmadsp/backend.py
+++ b/sigmadsp/backend.py
@@ -97,6 +97,9 @@ class BackendService(BackendServicer):
 
     def startup_worker(self):
         """A thread that performs a startup check and then starts the rest of the threads."""
+        # Reset the DSP first.
+        self.dsp.hard_reset()
+
         try:
             logger.info("Run startup safety check.")
             self.retry_safety_check()

--- a/sigmadsp/dsp/adau1x01.py
+++ b/sigmadsp/dsp/adau1x01.py
@@ -53,7 +53,7 @@ class Adau1x01(Dsp):
 
         Not available on ADAU1x01
         """
-        logger.info("Soft-resetting the DSP is not available on ADAU1x01")
+        logger.info("Soft-reset is not available on ADAU1x01")
 
     def safeload(self, address: int, data: bytes):
         """Write data to the chip using hardware safeload.

--- a/sigmadsp/dsp/common.py
+++ b/sigmadsp/dsp/common.py
@@ -150,16 +150,18 @@ class Dsp(ABC):
         """
         pin = self.get_pin_by_name("reset")
 
-        if not pin:
-            logger.info("Falling back to soft-resetting the DSP, no hard-reset pin is defined.")
-            self.soft_reset()
-            return
+        if pin:
+            logger.info("Hard-resetting the DSP.")
 
-        logger.info("Hard-resetting the DSP.")
+            pin.control.on()
+            time.sleep(delay)
+            pin.control.off()
 
-        pin.control.on()
-        time.sleep(delay)
-        pin.control.off()
+        else:
+            logger.warning("No hard-reset pin is defined, not resetting.")
+
+        # Soft-reset in the end, for flushing registers.
+        self.soft_reset()
 
     def write(self, address: int, data: bytes):
         """Write data to the DSP using the configured communication handler.

--- a/sigmadsp/dsp/factory.py
+++ b/sigmadsp/dsp/factory.py
@@ -103,7 +103,4 @@ def dsp_from_config(config: Dict) -> Dsp:
     except (KeyError, TypeError):
         logger.info("No DSP pin definitions were found in the configuration file.")
 
-    else:
-        dsp.hard_reset()
-
     return dsp


### PR DESCRIPTION
The safety check shall be re-run until the DSP register read returns feasible values.